### PR TITLE
Provides and conflicts

### DIFF
--- a/lastfm/PKGBUILD
+++ b/lastfm/PKGBUILD
@@ -15,7 +15,11 @@ source=(Last.fm-$pkgver.tar.bz2::http://www.last.fm/download/linux
     LAV_Source_fix.patch
     lastfm-scrobbler.desktop
     cast-bug.patch)
-
+conflicts=(lastfm-git
+    lastfm-mpd-cli
+    lastfm-msk
+    lastfm-msk-light)
+provides=lastfm
 
 #install=$pkgname.install
 


### PR DESCRIPTION
This will avoid that another installation of a lastfm version avoids your one to be installed
